### PR TITLE
Feature hwlib window adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 *.lst
 .idea/
 cmake*/
-
+settings.json

--- a/Makefile.due
+++ b/Makefile.due
@@ -11,7 +11,7 @@
 # settings for Arduino Due projects
 TARGET            ?= arduino_due
 SERIAL_PORT       ?= COM2
-CONSOLE_BAUDRATE  ?= 2400
+CONSOLE_BAUDRATE  ?= 115200
 STACK_SIZE        ?= 81920
 HEAP              ?= BMPTK
 

--- a/code/headers/display_adapter.hpp
+++ b/code/headers/display_adapter.hpp
@@ -68,7 +68,6 @@ namespace r2d2::display {
          * a flush if not needed
          *
          */
-        virtual void flush() override {
-        }
+        virtual void flush() override;
     };
 } // namespace r2d2::display

--- a/code/headers/display_adapter.hpp
+++ b/code/headers/display_adapter.hpp
@@ -6,7 +6,7 @@ namespace r2d2::display {
     class display : public hwlib::window {
     protected:
         /**
-         * @brief write implementation for hwlib
+         * @brief Write implementation for hwlib
          *
          * @param pos
          * @param col
@@ -16,7 +16,7 @@ namespace r2d2::display {
         }
 
         /**
-         * @brief converts a hwlib::color to the pixel data for the screen with
+         * @brief Converts a hwlib::color to the pixel data for the screen with
          * a maximum of two bytes for every pixel
          *
          * @param c
@@ -30,7 +30,7 @@ namespace r2d2::display {
         }
 
         /**
-         * @brief Directly write a pixel to the screen
+         * @brief Write a pixel to the screen
          *
          * @param x
          * @param y
@@ -39,7 +39,7 @@ namespace r2d2::display {
         virtual void set_pixel(uint16_t x, uint16_t y, const uint16_t data) = 0;
 
         /**
-         * @brief Directly write multiple pixels to the screen
+         * @brief Write multiple pixels to the screen
          *
          * @param x
          * @param y
@@ -48,10 +48,10 @@ namespace r2d2::display {
          * @param data
          */
         virtual void set_pixels(uint16_t x, uint16_t y, uint16_t width,
-                                uint16_t height, const uint16_t *data) = 0;
+                                uint16_t height, const uint16_t *data);
 
         /**
-         * @brief Directly fill multiple pixels with the same color to the
+         * @brief Fill multiple pixels with the same color to the
          * screen
          *
          * @param x
@@ -61,10 +61,10 @@ namespace r2d2::display {
          * @param data
          */
         virtual void set_pixels(uint16_t x, uint16_t y, uint16_t width,
-                                uint16_t height, const uint16_t data) = 0;
+                                uint16_t height, const uint16_t data);
 
         /**
-         * @brief override for hwlib::window the class doesn't need to implement
+         * @brief Override for hwlib::window the class doesn't need to implement
          * a flush if not needed
          *
          */

--- a/code/headers/display_adapter.hpp
+++ b/code/headers/display_adapter.hpp
@@ -15,6 +15,12 @@ namespace r2d2::display {
             set_pixel(pos.x, pos.y, color_to_pixel(col));
         }
 
+    public:
+        display(hwlib::xy size, hwlib::color foreground = hwlib::white,
+                hwlib::color background = hwlib::black)
+            : hwlib::window(size, foreground, background) {
+        }
+
         /**
          * @brief Converts a hwlib::color to the pixel data for the screen with
          * a maximum of two bytes for every pixel
@@ -22,12 +28,6 @@ namespace r2d2::display {
          * @param c
          */
         virtual uint16_t color_to_pixel(const hwlib::color &c) = 0;
-
-    public:
-        display(hwlib::xy size, hwlib::color foreground = hwlib::white,
-                hwlib::color background = hwlib::black)
-            : hwlib::window(size, foreground, background) {
-        }
 
         /**
          * @brief Write a pixel to the screen

--- a/code/headers/display_adapter.hpp
+++ b/code/headers/display_adapter.hpp
@@ -3,7 +3,7 @@
 #include <hwlib.hpp>
 
 namespace r2d2::display {
-    class display : public hwlib::window {
+    class display_c : public hwlib::window {
     protected:
         /**
          * @brief Write implementation for hwlib
@@ -16,7 +16,7 @@ namespace r2d2::display {
         }
 
     public:
-        display(hwlib::xy size, hwlib::color foreground = hwlib::white,
+        display_c(hwlib::xy size, hwlib::color foreground = hwlib::white,
                 hwlib::color background = hwlib::black)
             : hwlib::window(size, foreground, background) {
         }

--- a/code/headers/display_adapter.hpp
+++ b/code/headers/display_adapter.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <hwlib.hpp>
+
+namespace r2d2::display {
+    class display : public hwlib::window {
+    protected:
+        /**
+         * @brief write implementation for hwlib
+         *
+         * @param pos
+         * @param col
+         */
+        void write_implementation(hwlib::xy pos, hwlib::color col) {
+            set_pixel(pos.x, pos.y, color_to_pixel(col));
+        }
+
+        /**
+         * @brief converts a hwlib::color to the pixel data for the screen with
+         * a maximum of two bytes for every pixel
+         *
+         * @param c
+         */
+        virtual uint16_t color_to_pixel(const hwlib::color &c) = 0;
+
+    public:
+        display(hwlib::xy size, hwlib::color foreground = hwlib::white,
+                hwlib::color background = hwlib::black)
+            : hwlib::window(size, foreground, background) {
+        }
+
+        /**
+         * @brief Directly write a pixel to the screen
+         *
+         * @param x
+         * @param y
+         * @param data
+         */
+        virtual void set_pixel(uint16_t x, uint16_t y, const uint16_t data) = 0;
+
+        /**
+         * @brief Directly write multiple pixels to the screen
+         *
+         * @param x
+         * @param y
+         * @param width
+         * @param height
+         * @param data
+         */
+        virtual void set_pixels(uint16_t x, uint16_t y, uint16_t width,
+                                uint16_t height, const uint16_t *data) = 0;
+
+        /**
+         * @brief Directly fill multiple pixels with the same color to the
+         * screen
+         *
+         * @param x
+         * @param y
+         * @param width
+         * @param height
+         * @param data
+         */
+        virtual void set_pixels(uint16_t x, uint16_t y, uint16_t width,
+                                uint16_t height, const uint16_t data) = 0;
+
+        /**
+         * @brief override for hwlib::window the class doesn't need to implement
+         * a flush if not needed
+         *
+         */
+        virtual void flush() override {
+        }
+    };
+} // namespace r2d2::display

--- a/code/headers/ssd1306.hpp
+++ b/code/headers/ssd1306.hpp
@@ -92,7 +92,7 @@ namespace r2d2::display {
             (uint8_t)ssd1306_command::display_on};
     };
 
-    class ssd1306_i2c_c: public ssd1306_c {
+    class ssd1306_i2c_c : public ssd1306_c {
     protected:
         /// The I2C bus
         r2d2::i2c::i2c_bus_c bus;

--- a/code/headers/ssd1306.hpp
+++ b/code/headers/ssd1306.hpp
@@ -4,92 +4,95 @@
 #include <i2c_bus.hpp>
 
 namespace r2d2::display {
-    enum class ssd1306_command : uint8_t {
-        set_contrast = 0x81,
-        display_all_on_resume = 0xa4,
-        display_all_on = 0xa5,
-        normal_display = 0xa6,
-        invert_display = 0xa7,
-        display_off = 0xae,
-        display_on = 0xaf,
-        set_display_offset = 0xd3,
-        set_compins = 0xda,
-        set_vcom_detect = 0xdb,
-        set_display_clock_div = 0xd5,
-        set_precharge = 0xd9,
-        set_multiplex = 0xa8,
-        set_low_column = 0x00,
-        set_high_column = 0x10,
-        set_start_line = 0x40,
-        memory_mode = 0x20,
-        column_addr = 0x21,
-        page_addr = 0x22,
-        com_scan_inc = 0xc0,
-        com_scan_dec = 0xc8,
-        seg_remap = 0xa0,
-        charge_pump = 0x8d,
-        external_vcc = 0x01,
-        switch_cap_vcc = 0x02,
-        activate_scroll = 0x2f,
-        deactivate_scroll = 0x2e,
-        set_vertical_scroll_area = 0xa3,
-        right_horizontal_scroll = 0x26,
-        left_horizontal_scroll = 0x27,
-        vertical_and_right_horizontal_scroll = 0x29,
-        vertical_and_left_horizontal_scroll = 0x2A
+    class ssd1306_c {
+    public:
+        enum class ssd1306_command : uint8_t {
+            set_contrast = 0x81,
+            display_all_on_resume = 0xa4,
+            display_all_on = 0xa5,
+            normal_display = 0xa6,
+            invert_display = 0xa7,
+            display_off = 0xae,
+            display_on = 0xaf,
+            set_display_offset = 0xd3,
+            set_compins = 0xda,
+            set_vcom_detect = 0xdb,
+            set_display_clock_div = 0xd5,
+            set_precharge = 0xd9,
+            set_multiplex = 0xa8,
+            set_low_column = 0x00,
+            set_high_column = 0x10,
+            set_start_line = 0x40,
+            memory_mode = 0x20,
+            column_addr = 0x21,
+            page_addr = 0x22,
+            com_scan_inc = 0xc0,
+            com_scan_dec = 0xc8,
+            seg_remap = 0xa0,
+            charge_pump = 0x8d,
+            external_vcc = 0x01,
+            switch_cap_vcc = 0x02,
+            activate_scroll = 0x2f,
+            deactivate_scroll = 0x2e,
+            set_vertical_scroll_area = 0xa3,
+            right_horizontal_scroll = 0x26,
+            left_horizontal_scroll = 0x27,
+            vertical_and_right_horizontal_scroll = 0x29,
+            vertical_and_left_horizontal_scroll = 0x2A
+        };
+
+        /// value to send over i2c before a command
+        constexpr static uint8_t ssd1306_cmd_prefix = 0x80;
+
+        /// value to send over i2c before data
+        constexpr static uint8_t ssd1306_data_prefix = 0x40;
+
+        /// SSD1306 chip initialization
+        constexpr static uint8_t ssd1306_initialization[] = {
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::display_off,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_display_clock_div,
+            0x80,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_multiplex,
+            0x3f,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_display_offset,
+            0x00,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_start_line | 0x00,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::charge_pump,
+            0x14,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::memory_mode,
+            0x00,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::seg_remap | 0x01,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::com_scan_dec,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_compins,
+            0x12,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_contrast,
+            0xcf,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_precharge,
+            0xf1,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::set_vcom_detect,
+            0x40,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::display_all_on_resume,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::normal_display,
+            ssd1306_cmd_prefix,
+            (uint8_t)ssd1306_command::display_on};
     };
 
-    /// value to send over i2c before a command
-    constexpr uint8_t ssd1306_cmd_prefix = 0x80;
-
-    /// value to send over i2c before data
-    constexpr uint8_t ssd1306_data_prefix = 0x40;
-
-    /// SSD1306 chip initialization
-    constexpr const uint8_t ssd1306_initialization[] = {
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::display_off,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_display_clock_div,
-        0x80,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_multiplex,
-        0x3f,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_display_offset,
-        0x00,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_start_line | 0x00,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::charge_pump,
-        0x14,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::memory_mode,
-        0x00,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::seg_remap | 0x01,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::com_scan_dec,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_compins,
-        0x12,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_contrast,
-        0xcf,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_precharge,
-        0xf1,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::set_vcom_detect,
-        0x40,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::display_all_on_resume,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::normal_display,
-        ssd1306_cmd_prefix,
-        (uint8_t)ssd1306_command::display_on};
-
-    class ssd1306_i2c_c {
+    class ssd1306_i2c_c: public ssd1306_c {
     protected:
         /// The I2C bus
         r2d2::i2c::i2c_bus_c bus;

--- a/code/headers/ssd1306_oled_buffered.hpp
+++ b/code/headers/ssd1306_oled_buffered.hpp
@@ -7,48 +7,54 @@
 namespace r2d2::display {
     /**
      * SSD1306 buffered interface for an oled
-     * Implements hwlib::window to easily use text and drawing functions that are already implemented.
-     * Extends from r2d2::display::ssd1306_i2c_c 
+     * Implements hwlib::window to easily use text and drawing functions that
+     * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
     class ssd1306_oled_buffered_c : public r2d2::display::ssd1306_i2c_c,
                                     public hwlib::window {
     private:
         /**
          * The size of the display
-         * This is needed even though hwlib::window keeps it's own size to create the buffer at compile time.
-         */ 
+         * This is needed even though hwlib::window keeps it's own size to
+         * create the buffer at compile time.
+         */
         static auto constexpr wsize = hwlib::xy(128, 64);
 
         /**
          * The buffer with the pixel data
-         * The first byte is used for the data-prefix that the display driver requires to be sent when sending pixel data.
-         */ 
+         * The first byte is used for the data-prefix that the display driver
+         * requires to be sent when sending pixel data.
+         */
         uint8_t buffer[(wsize.x * wsize.y / 8) + 1] = {};
 
         /**
          * The write implementation of hwlib::window
          * This is what allows us to re-use the existing code.
-         * It sets a pixel at the given coordinate to the given color. In the case of this specific display the color is either white or black.
-         */ 
+         * It sets a pixel at the given coordinate to the given color. In the
+         * case of this specific display the color is either white or black.
+         */
         void write_implementation(hwlib::xy pos, hwlib::color col) override;
 
     public:
         /**
-         * Construct the display driver by providing the communication bus and the address of the display.
-         */ 
+         * Construct the display driver by providing the communication bus and
+         * the address of the display.
+         */
         ssd1306_oled_buffered_c(r2d2::i2c::i2c_bus_c &bus,
                                 const uint8_t &address);
 
         /**
          * Clears the display.
          * Sets all pixels to "off"
-         */ 
+         */
         void clear() override;
 
         /**
-         * Flushes the data to the display. 
-         * All the data is kept in a buffer on the arduino until this function is called, it will then push the entirety of the buffer to the display at once.
-         */ 
+         * Flushes the data to the display.
+         * All the data is kept in a buffer on the arduino until this function
+         * is called, it will then push the entirety of the buffer to the
+         * display at once.
+         */
         void flush() override;
     };
 

--- a/code/headers/ssd1306_oled_buffered.hpp
+++ b/code/headers/ssd1306_oled_buffered.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <hwlib.hpp>
+
 #include <i2c_bus.hpp>
 #include <ssd1306.hpp>
+#include <display_adapter.hpp>
 
 namespace r2d2::display {
     /**
@@ -10,8 +12,7 @@ namespace r2d2::display {
      * Implements hwlib::window to easily use text and drawing functions that
      * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
-    class ssd1306_oled_buffered_c : public r2d2::display::ssd1306_i2c_c,
-                                    public hwlib::window {
+    class ssd1306_oled_buffered_c : protected ssd1306_i2c_c, public display {
     private:
         /**
          * The size of the display
@@ -27,13 +28,13 @@ namespace r2d2::display {
          */
         uint8_t buffer[(wsize.x * wsize.y / 8) + 1] = {};
 
-        /**
-         * The write implementation of hwlib::window
-         * This is what allows us to re-use the existing code.
-         * It sets a pixel at the given coordinate to the given color. In the
-         * case of this specific display the color is either white or black.
-         */
-        void write_implementation(hwlib::xy pos, hwlib::color col) override;
+        // /**
+        //  * The write implementation of hwlib::window
+        //  * This is what allows us to re-use the existing code.
+        //  * It sets a pixel at the given coordinate to the given color. In the
+        //  * case of this specific display the color is either white or black.
+        //  */
+        // void write_implementation(hwlib::xy pos, hwlib::color col) override;
 
     public:
         /**
@@ -47,7 +48,7 @@ namespace r2d2::display {
          * Clears the display.
          * Sets all pixels to "off"
          */
-        void clear() override;
+        void clear(hwlib::color col);
 
         /**
          * Flushes the data to the display.
@@ -55,7 +56,7 @@ namespace r2d2::display {
          * is called, it will then push the entirety of the buffer to the
          * display at once.
          */
-        void flush() override;
+        void flush();
     };
 
 } // namespace r2d2::display

--- a/code/headers/ssd1306_oled_buffered.hpp
+++ b/code/headers/ssd1306_oled_buffered.hpp
@@ -12,7 +12,7 @@ namespace r2d2::display {
      * Implements hwlib::window to easily use text and drawing functions that
      * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
-    class ssd1306_oled_buffered_c : public display, protected ssd1306_i2c_c {
+    class ssd1306_oled_buffered_c : public display_c, protected ssd1306_i2c_c {
     private:
         /**
          * The size of the display

--- a/code/headers/ssd1306_oled_buffered.hpp
+++ b/code/headers/ssd1306_oled_buffered.hpp
@@ -2,9 +2,9 @@
 
 #include <hwlib.hpp>
 
+#include <display_adapter.hpp>
 #include <i2c_bus.hpp>
 #include <ssd1306.hpp>
-#include <display_adapter.hpp>
 
 namespace r2d2::display {
     /**
@@ -12,7 +12,7 @@ namespace r2d2::display {
      * Implements hwlib::window to easily use text and drawing functions that
      * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
-    class ssd1306_oled_buffered_c : protected ssd1306_i2c_c, public display {
+    class ssd1306_oled_buffered_c : public display, protected ssd1306_i2c_c {
     private:
         /**
          * The size of the display
@@ -28,13 +28,13 @@ namespace r2d2::display {
          */
         uint8_t buffer[(wsize.x * wsize.y / 8) + 1] = {};
 
-        // /**
-        //  * The write implementation of hwlib::window
-        //  * This is what allows us to re-use the existing code.
-        //  * It sets a pixel at the given coordinate to the given color. In the
-        //  * case of this specific display the color is either white or black.
-        //  */
-        // void write_implementation(hwlib::xy pos, hwlib::color col) override;
+        /**
+         * @brief converts a hwlib::color to the pixel data for the screen with
+         * a maximum of two bytes for every pixel
+         *
+         * @param c
+         */
+        uint16_t color_to_pixel(const hwlib::color &c) override;
 
     public:
         /**
@@ -45,10 +45,25 @@ namespace r2d2::display {
                                 const uint8_t &address);
 
         /**
-         * Clears the display.
-         * Sets all pixels to "off"
+         * @brief Write a pixel to the screen
+         *
+         * @param x
+         * @param y
+         * @param data
          */
-        void clear(hwlib::color col);
+        void set_pixel(uint16_t x, uint16_t y, const uint16_t data) override;
+
+        /**
+         * This clears the display this overrides the default clear of hwlib
+         * becouse it is realy inefficient for this screen.
+         */
+        void clear(hwlib::color col) override;
+
+        /**
+         * This clears the display this overrides the default clear of hwlib
+         * becouse it is realy inefficient for this screen.
+         */
+        void clear() override;
 
         /**
          * Flushes the data to the display.

--- a/code/headers/ssd1306_oled_unbuffered.hpp
+++ b/code/headers/ssd1306_oled_unbuffered.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <hwlib.hpp>
+
+#include <display_adapter.hpp>
 #include <i2c_bus.hpp>
 #include <ssd1306.hpp>
 
@@ -10,8 +12,7 @@ namespace r2d2::display {
      * Implements hwlib::window to easily use text and drawing functions that
      * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
-    class ssd1306_oled_unbuffered_c : public r2d2::display::ssd1306_i2c_c,
-                                      public hwlib::window {
+    class ssd1306_oled_unbuffered_c : public display, public ssd1306_i2c_c {
     private:
         /**
          * The size of the display
@@ -27,14 +28,6 @@ namespace r2d2::display {
          */
         uint8_t buffer[wsize.x * wsize.y / 8] = {};
 
-        /**
-         * The write implementation of hwlib::window
-         * This is what allows us to re-use the existing code.
-         * It sets a pixel at the given coordinate to the given color. In the
-         * case of this specific display the color is either white or black.
-         */
-        void write_implementation(hwlib::xy pos, hwlib::color col) override;
-
     public:
         /**
          * Construct the display driver by providing the communication bus and
@@ -44,15 +37,33 @@ namespace r2d2::display {
                                   const uint8_t &address);
 
         /**
-         * Clears the display.
-         * Sets all pixels to "off"
+         * @brief Write a pixel to the screen
+         *
+         * @param x
+         * @param y
+         * @param data
+         */
+        void set_pixel(uint16_t x, uint16_t y, const uint16_t data) override;
+
+        /**
+         * This clears the display this overrides the default clear of hwlib
+         * becouse it is realy inefficient for this screen.
+         */
+        void clear(hwlib::color col) override;
+
+        /**
+         * This clears the display this overrides the default clear of hwlib
+         * becouse it is realy inefficient for this screen.
          */
         void clear() override;
 
         /**
-         * Does nothing.
+         * @brief Converts a hwlib::color to the pixel data for the screen with
+         * a maximum of two bytes for every pixel
+         *
+         * @param c
          */
-        void flush() override;
+        uint16_t color_to_pixel(const hwlib::color &c);
     };
 
 } // namespace r2d2::display

--- a/code/headers/ssd1306_oled_unbuffered.hpp
+++ b/code/headers/ssd1306_oled_unbuffered.hpp
@@ -12,7 +12,7 @@ namespace r2d2::display {
      * Implements hwlib::window to easily use text and drawing functions that
      * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
-    class ssd1306_oled_unbuffered_c : public display, public ssd1306_i2c_c {
+    class ssd1306_oled_unbuffered_c : public display_c, public ssd1306_i2c_c {
     private:
         /**
          * The size of the display

--- a/code/headers/ssd1306_oled_unbuffered.hpp
+++ b/code/headers/ssd1306_oled_unbuffered.hpp
@@ -1,4 +1,4 @@
-#pragma  once
+#pragma once
 
 #include <hwlib.hpp>
 #include <i2c_bus.hpp>
@@ -7,47 +7,51 @@
 namespace r2d2::display {
     /**
      * SSD1306 unbuffered interface for an oled
-     * Implements hwlib::window to easily use text and drawing functions that are already implemented.
-     * Extends from r2d2::display::ssd1306_i2c_c 
+     * Implements hwlib::window to easily use text and drawing functions that
+     * are already implemented. Extends from r2d2::display::ssd1306_i2c_c
      */
     class ssd1306_oled_unbuffered_c : public r2d2::display::ssd1306_i2c_c,
-                                    public hwlib::window {
+                                      public hwlib::window {
     private:
         /**
          * The size of the display
-         * This is needed even though hwlib::window keeps it's own size to create the buffer at compile time.
-         */ 
+         * This is needed even though hwlib::window keeps it's own size to
+         * create the buffer at compile time.
+         */
         static auto constexpr wsize = hwlib::xy(128, 64);
 
         /**
          * The buffer with the pixel data
-         * The first byte is used for the data-prefix that the display driver requires to be sent when sending pixel data.
-         */ 
+         * The first byte is used for the data-prefix that the display driver
+         * requires to be sent when sending pixel data.
+         */
         uint8_t buffer[wsize.x * wsize.y / 8] = {};
 
         /**
          * The write implementation of hwlib::window
          * This is what allows us to re-use the existing code.
-         * It sets a pixel at the given coordinate to the given color. In the case of this specific display the color is either white or black.
-         */ 
+         * It sets a pixel at the given coordinate to the given color. In the
+         * case of this specific display the color is either white or black.
+         */
         void write_implementation(hwlib::xy pos, hwlib::color col) override;
 
     public:
         /**
-         * Construct the display driver by providing the communication bus and the address of the display.
-         */ 
+         * Construct the display driver by providing the communication bus and
+         * the address of the display.
+         */
         ssd1306_oled_unbuffered_c(r2d2::i2c::i2c_bus_c &bus,
-                                const uint8_t &address);
+                                  const uint8_t &address);
 
         /**
          * Clears the display.
          * Sets all pixels to "off"
-         */ 
+         */
         void clear() override;
 
         /**
          * Does nothing.
-         */ 
+         */
         void flush() override;
     };
 

--- a/code/headers/ssd1306_oled_unbuffered.hpp
+++ b/code/headers/ssd1306_oled_unbuffered.hpp
@@ -26,7 +26,7 @@ namespace r2d2::display {
          * The first byte is used for the data-prefix that the display driver
          * requires to be sent when sending pixel data.
          */
-        uint8_t buffer[wsize.x * wsize.y / 8] = {};
+        uint8_t buffer[wsize.x * wsize.y / 8 + 1] = {};
 
     public:
         /**

--- a/code/src/display_adapter.cpp
+++ b/code/src/display_adapter.cpp
@@ -1,0 +1,25 @@
+#include <display_adapter.hpp>
+
+namespace r2d2::display {
+    void display::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                             const uint16_t *data) {
+        // set the data to the correct pixel
+        for (size_t t_y = 0; t_y < w; t_y++) {
+            for (size_t t_x = 0; t_x < w; t_x++) {
+                // set the pixel with data at location of t_x + t_y * w
+                set_pixel(x + t_x, y + t_y, data[t_x + (t_y * w)]);
+            }
+        }
+    }
+
+    void display::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                             const uint16_t data) {
+        // set all the pixels to data
+        for (size_t t_y = 0; t_y < w; t_y++) {
+            for (size_t t_x = 0; t_x < w; t_x++) {
+                // set the pixel with datas
+                set_pixel(x + t_x, y + t_y, data);
+            }
+        }
+    }
+} // namespace r2d2::display

--- a/code/src/display_adapter.cpp
+++ b/code/src/display_adapter.cpp
@@ -1,7 +1,7 @@
 #include <display_adapter.hpp>
 
 namespace r2d2::display {
-    void display::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+    void display_c::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
                              const uint16_t *data) {
         // set the data to the correct pixel
         for (size_t t_y = 0; t_y < w; t_y++) {
@@ -12,7 +12,7 @@ namespace r2d2::display {
         }
     }
 
-    void display::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+    void display_c::set_pixels(uint16_t x, uint16_t y, uint16_t w, uint16_t h,
                              const uint16_t data) {
         // set all the pixels to data
         for (size_t t_y = 0; t_y < w; t_y++) {
@@ -23,6 +23,6 @@ namespace r2d2::display {
         }
     }
 
-    void display::flush() {
+    void display_c::flush() {
     }
 } // namespace r2d2::display

--- a/code/src/display_adapter.cpp
+++ b/code/src/display_adapter.cpp
@@ -22,4 +22,7 @@ namespace r2d2::display {
             }
         }
     }
+
+    void display::flush() {
+    }
 } // namespace r2d2::display

--- a/code/src/ssd1306.cpp
+++ b/code/src/ssd1306.cpp
@@ -4,39 +4,56 @@
 namespace r2d2::display {
     ssd1306_i2c_c::ssd1306_i2c_c(r2d2::i2c::i2c_bus_c &bus,
                                  const uint8_t &address)
-        : bus(bus), address(address), cursor(255, 255) {}
+        : bus(bus), address(address), cursor(255, 255) {
+    }
 
     void ssd1306_i2c_c::command(ssd1306_command c) {
+        // create command packet
         uint8_t data[] = {ssd1306_cmd_prefix, (uint8_t)c};
+
+        // write command to the bus
         bus.write(address, data, sizeof(data) / sizeof(uint8_t));
     }
 
     void ssd1306_i2c_c::command(ssd1306_command c, uint8_t d0) {
+        // create command packet
         uint8_t data[] = {ssd1306_cmd_prefix, (uint8_t)c, ssd1306_cmd_prefix,
                           d0};
+
+        // write command to the bus
         bus.write(address, data, sizeof(data) / sizeof(uint8_t));
     }
 
     void ssd1306_i2c_c::command(ssd1306_command c, uint8_t d0, uint8_t d1) {
+        // create command packet
         uint8_t data[] = {ssd1306_cmd_prefix, (uint8_t)c,
                           ssd1306_cmd_prefix, d0,
                           ssd1306_cmd_prefix, d1};
+
+        // write command to the bus
         bus.write(address, data, sizeof(data) / sizeof(uint8_t));
     }
 
     void ssd1306_i2c_c::data(uint8_t d) {
+        // create data packet
         uint8_t data[] = {ssd1306_data_prefix, d};
+        
+        // write data to the bus
         bus.write(address, data, sizeof(data) / sizeof(uint8_t));
     }
     void ssd1306_i2c_c::pixels_byte_write(hwlib::xy location, uint8_t d) {
 
+        // check if we need to update the current cursor of the screen
         if (location != cursor) {
             command(ssd1306_command::column_addr, location.x, 127);
             command(ssd1306_command::page_addr, location.y, 7);
             cursor = location;
         }
 
+        // write data to the screen
         data(d);
-        cursor.x++;
+
+        // update the local cursor
+        cursor.x++; // TODO: cursor fallthrough
     }
 } // namespace r2d2::display

--- a/code/src/ssd1306_oled_buffered.cpp
+++ b/code/src/ssd1306_oled_buffered.cpp
@@ -1,29 +1,29 @@
 #include "ssd1306_oled_buffered.hpp"
 
 namespace r2d2::display {
-    void ssd1306_oled_buffered_c::write_implementation(hwlib::xy pos,
-                                                     hwlib::color col) {
-        int a = pos.x + (pos.y / 8) * size.x;
-        if (col == hwlib::white) {
-            buffer[a + 1] |= (0x01 << (pos.y % 8));
-        } else {
-            buffer[a + 1] &= ~(0x01 << (pos.y % 8));
-        }
-    }
-
     ssd1306_oled_buffered_c::ssd1306_oled_buffered_c(r2d2::i2c::i2c_bus_c &bus,
                                                  const uint8_t &address)
-        : ssd1306_i2c_c(bus, address),
-          window(wsize, hwlib::white, hwlib::black) {
+        : ssd1306_i2c_c(bus, address) {
+        display(wsize, hwlib::white, hwlib::black) {
         bus.write(address, ssd1306_initialization,
                   sizeof(ssd1306_initialization) / sizeof(uint8_t));
     }
-    void ssd1306_oled_buffered_c::clear() {
-        const uint8_t d = (background == hwlib::white) ? 0xFF : 0x00;
+
+    // void ssd1306_oled_buffered_c::write_implementation(hwlib::xy pos,
+    //                                                  hwlib::color col) {
+    //     int a = pos.x + (pos.y / 8) * size.x;
+    //     if (col == hwlib::white) {
+    //         buffer[a + 1] |= (0x01 << (pos.y % 8));
+    //     } else {
+    //         buffer[a + 1] &= ~(0x01 << (pos.y % 8));
+    //     }
+    // }
+
+    void ssd1306_oled_buffered_c::clear(hwlib::color col) {
+        const uint8_t d = (col == hwlib::white) ? 0xFF : 0x00;
         for (uint_fast16_t x = 1; x < sizeof(buffer); ++x) {
             buffer[x] = d;
         }
-        cursor = size;
     }
 
     void ssd1306_oled_buffered_c::flush() {

--- a/code/src/ssd1306_oled_buffered.cpp
+++ b/code/src/ssd1306_oled_buffered.cpp
@@ -3,7 +3,7 @@
 namespace r2d2::display {
     ssd1306_oled_buffered_c::ssd1306_oled_buffered_c(r2d2::i2c::i2c_bus_c &bus,
                                                      const uint8_t &address)
-        : display(wsize, hwlib::white, hwlib::black),
+        : display_c(wsize, hwlib::white, hwlib::black),
           ssd1306_i2c_c(bus, address) {
 
         // set the command for writing to the screen

--- a/code/src/ssd1306_oled_buffered.cpp
+++ b/code/src/ssd1306_oled_buffered.cpp
@@ -2,34 +2,55 @@
 
 namespace r2d2::display {
     ssd1306_oled_buffered_c::ssd1306_oled_buffered_c(r2d2::i2c::i2c_bus_c &bus,
-                                                 const uint8_t &address)
-        : ssd1306_i2c_c(bus, address) {
-        display(wsize, hwlib::white, hwlib::black) {
+                                                     const uint8_t &address)
+        : display(wsize, hwlib::white, hwlib::black),
+          ssd1306_i2c_c(bus, address) {
+
+        buffer[0] = ssd1306_data_prefix;
+
         bus.write(address, ssd1306_initialization,
                   sizeof(ssd1306_initialization) / sizeof(uint8_t));
     }
 
-    // void ssd1306_oled_buffered_c::write_implementation(hwlib::xy pos,
-    //                                                  hwlib::color col) {
-    //     int a = pos.x + (pos.y / 8) * size.x;
-    //     if (col == hwlib::white) {
-    //         buffer[a + 1] |= (0x01 << (pos.y % 8));
-    //     } else {
-    //         buffer[a + 1] &= ~(0x01 << (pos.y % 8));
-    //     }
-    // }
+    void ssd1306_oled_buffered_c::set_pixel(uint16_t x, uint16_t y,
+                                            const uint16_t data) {
+        // calculate the index of the pixel
+        uint8_t t_index = x + (y / 8) * size.x;
+
+        // set or clear the pixel
+        if (data) {
+            buffer[t_index + 1] |= (0x01 << (y % 8));
+        } else {
+            buffer[t_index + 1] &= ~(0x01 << (y % 8));
+        }
+    }    
+
+    void ssd1306_oled_buffered_c::clear() {
+        // clear the screen with the background
+        clear(background);
+    }
 
     void ssd1306_oled_buffered_c::clear(hwlib::color col) {
+        // get a the data for the screen
         const uint8_t d = (col == hwlib::white) ? 0xFF : 0x00;
+
+        // set all values to the color of the data
         for (uint_fast16_t x = 1; x < sizeof(buffer); ++x) {
             buffer[x] = d;
         }
     }
 
     void ssd1306_oled_buffered_c::flush() {
+        // update cursor of the display
         command(ssd1306_command::column_addr, 0, 127);
         command(ssd1306_command::page_addr, 0, 7);
-        buffer[0] = ssd1306_data_prefix;
+
+        // write data to the screen
         bus.write(address, buffer, sizeof(buffer));
+    }
+
+    uint16_t ssd1306_oled_buffered_c::color_to_pixel(const hwlib::color &c) {
+        // return as bool becouse we only need bools for the display
+        return (c == hwlib::white);
     }
 } // namespace r2d2::display

--- a/code/src/ssd1306_oled_buffered.cpp
+++ b/code/src/ssd1306_oled_buffered.cpp
@@ -6,8 +6,10 @@ namespace r2d2::display {
         : display(wsize, hwlib::white, hwlib::black),
           ssd1306_i2c_c(bus, address) {
 
+        // set the command for writing to the screen
         buffer[0] = ssd1306_data_prefix;
 
+        // write the initalisation sequence to the screen
         bus.write(address, ssd1306_initialization,
                   sizeof(ssd1306_initialization) / sizeof(uint8_t));
     }
@@ -15,7 +17,7 @@ namespace r2d2::display {
     void ssd1306_oled_buffered_c::set_pixel(uint16_t x, uint16_t y,
                                             const uint16_t data) {
         // calculate the index of the pixel
-        uint8_t t_index = x + (y / 8) * size.x;
+        uint16_t t_index = x + (y / 8) * size.x;
 
         // set or clear the pixel
         if (data) {

--- a/code/src/ssd1306_oled_buffered.cpp
+++ b/code/src/ssd1306_oled_buffered.cpp
@@ -17,13 +17,13 @@ namespace r2d2::display {
     void ssd1306_oled_buffered_c::set_pixel(uint16_t x, uint16_t y,
                                             const uint16_t data) {
         // calculate the index of the pixel
-        uint16_t t_index = x + (y / 8) * size.x;
+        uint16_t t_index = (x + (y / 8) * size.x) + 1;
 
         // set or clear the pixel
         if (data) {
-            buffer[t_index + 1] |= (0x01 << (y % 8));
+            buffer[t_index] |= (0x01 << (y % 8));
         } else {
-            buffer[t_index + 1] &= ~(0x01 << (y % 8));
+            buffer[t_index] &= ~(0x01 << (y % 8));
         }
     }    
 

--- a/code/src/ssd1306_oled_unbuffered.cpp
+++ b/code/src/ssd1306_oled_unbuffered.cpp
@@ -1,39 +1,65 @@
 #include "ssd1306_oled_unbuffered.hpp"
 
 namespace r2d2::display {
-    void ssd1306_oled_unbuffered_c::write_implementation(hwlib::xy pos,
-                                                       hwlib::color col) {
+    ssd1306_oled_unbuffered_c::ssd1306_oled_unbuffered_c(
+        r2d2::i2c::i2c_bus_c &bus, const uint8_t &address)
+        : display(wsize), ssd1306_i2c_c(bus, address) {
 
-        int a = pos.x + (pos.y / 8) * size.x;
-        if (col == hwlib::white) {
-            buffer[a] |= (0x01 << (pos.y % 8));
-        } else {
-            buffer[a] &= ~(0x01 << (pos.y % 8));
-        }
-
-        pixels_byte_write(hwlib::xy(pos.x, pos.y / 8), buffer[a]);
-    }
-
-    ssd1306_oled_unbuffered_c::ssd1306_oled_unbuffered_c(r2d2::i2c::i2c_bus_c &bus,
-                                                     const uint8_t &address)
-        : ssd1306_i2c_c(bus, address),
-          window(wsize, hwlib::white, hwlib::black) {
+        // write the initalisation sequence to the screen
         bus.write(address, ssd1306_initialization,
                   sizeof(ssd1306_initialization) / sizeof(uint8_t));
     }
+
+    void ssd1306_oled_unbuffered_c::set_pixel(uint16_t x, uint16_t y,
+                                              const uint16_t data) {
+
+        // calculate the index of the pixel
+        uint16_t a = x + (y / 8) * size.x;
+
+        // set or clear the pixel
+        if (data) {
+            buffer[a] |= (0x01 << (y % 8));
+        } else {
+            buffer[a] &= ~(0x01 << (y % 8));
+        }
+
+        // write pixel byte to screen
+        pixels_byte_write(hwlib::xy(x, y / 8), buffer[a]);
+    }
+
     void ssd1306_oled_unbuffered_c::clear() {
-        const uint8_t d = (background == hwlib::white) ? 0xFF : 0x00;
+        // clear the display
+        clear(background);
+    }
+
+    void ssd1306_oled_unbuffered_c::clear(hwlib::color col) {
+        // get a the data for the screen
+        const uint8_t d = (col == hwlib::white) ? 0xFF : 0x00;
+
+        // update cursor of the display
         command(ssd1306_command::column_addr, 0, 127);
         command(ssd1306_command::page_addr, 0, 7);
+
+        // create buffer for the display
         uint8_t data[sizeof(buffer) + 1] = {0};
+
+        // set the command for writing to the screen
         data[0] = ssd1306_data_prefix;
+
+        // set all the data
         for (uint_fast16_t x = 1; x < sizeof(data); ++x) {
             data[x] = d;
         }
+
+        // write all the data to the bus
         bus.write(address, data, sizeof(data));
-        cursor = hwlib::xy(0,0);
+
+        // update the cursor
+        cursor = hwlib::xy(0, 0);
     }
 
-    void ssd1306_oled_unbuffered_c::flush() {
+    uint16_t ssd1306_oled_unbuffered_c::color_to_pixel(const hwlib::color &c) {
+        // return as bool becouse we only need bools for the display
+        return (c == hwlib::white);
     }
 } // namespace r2d2::display

--- a/code/src/ssd1306_oled_unbuffered.cpp
+++ b/code/src/ssd1306_oled_unbuffered.cpp
@@ -14,17 +14,17 @@ namespace r2d2::display {
                                               const uint16_t data) {
 
         // calculate the index of the pixel
-        uint16_t a = x + (y / 8) * size.x;
+        uint16_t t_index = x + (y / 8) * size.x;
 
         // set or clear the pixel
         if (data) {
-            buffer[a] |= (0x01 << (y % 8));
+            buffer[t_index] |= (0x01 << (y % 8));
         } else {
-            buffer[a] &= ~(0x01 << (y % 8));
+            buffer[t_index] &= ~(0x01 << (y % 8));
         }
 
         // write pixel byte to screen
-        pixels_byte_write(hwlib::xy(x, y / 8), buffer[a]);
+        pixels_byte_write(hwlib::xy(x, y / 8), buffer[t_index]);
     }
 
     void ssd1306_oled_unbuffered_c::clear() {

--- a/code/src/ssd1306_oled_unbuffered.cpp
+++ b/code/src/ssd1306_oled_unbuffered.cpp
@@ -3,7 +3,7 @@
 namespace r2d2::display {
     ssd1306_oled_unbuffered_c::ssd1306_oled_unbuffered_c(
         r2d2::i2c::i2c_bus_c &bus, const uint8_t &address)
-        : display(wsize), ssd1306_i2c_c(bus, address) {
+        : display_c(wsize), ssd1306_i2c_c(bus, address) {
 
         // set the command for writing to the screen
         buffer[0] = ssd1306_data_prefix;


### PR DESCRIPTION
This changes the inheritance to r2d2::display::display_c to allow for faster set_pixels for unbuffered display's. Because the st7735 can set ranges of the pixels. This removes the need to update the cursor the whole time. 

Tested the buffered and the unbuffered implementation of the ssd1306 and both work.
